### PR TITLE
Convert package to iOS app

### DIFF
--- a/MoodTrackerApp/Info.plist
+++ b/MoodTrackerApp/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>应用需要使用语音识别来转录您的语音输入。</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>应用需要访问麦克风来录制语音。</string>
+    <key>NSHealthShareUsageDescription</key>
+    <string>应用需要访问您的健康数据以提供个性化建议。</string>
+    <key>NSHealthUpdateUsageDescription</key>
+    <string>应用需要更新健康数据以记录您的活动。</string>
+</dict>
+</plist>

--- a/MoodTrackerApp/Services/HealthService.swift
+++ b/MoodTrackerApp/Services/HealthService.swift
@@ -2,7 +2,7 @@ import Foundation
 import HealthKit
 
 /// 封装 Apple Health 数据交互的服务，支持请求授权和获取数据。
-@available(macOS 13.0, *)
+@available(iOS 15.0, *)
 @MainActor
 final class HealthService {
     static let shared = HealthService()

--- a/MoodTrackerApp/Services/SpeechService.swift
+++ b/MoodTrackerApp/Services/SpeechService.swift
@@ -2,7 +2,7 @@ import Foundation
 import Speech
 import AVFoundation
 
-@available(macOS 10.15, *)
+@available(iOS 15.0, macOS 10.15, *)
 @MainActor
 final class SpeechService: NSObject, ObservableObject {
     @Published var transcribedText: String = ""

--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,31 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
+#if os(macOS)
+let products: [Product] = [
+    .iOSApplication(
+        name: "MoodTrackerApp",
+        targets: ["MoodTrackerApp"],
+        bundleIdentifier: "com.example.MoodTrackerApp",
+        teamIdentifier: "ABCDE12345",
+        displayVersion: "1.0",
+        bundleVersion: "1",
+        infoPlist: .file(path: "MoodTrackerApp/Info.plist"),
+        appCategory: .healthcareAndFitness
+    )
+]
+#else
+let products: [Product] = [
+    .executable(name: "MoodTrackerApp", targets: ["MoodTrackerApp"])
+]
+#endif
+
 let package = Package(
     name: "MoodTrackerAppPackage",
     platforms: [
-        .macOS(.v13)
+        .iOS(.v16)
     ],
-    products: [
-        .executable(name: "MoodTrackerApp", targets: ["MoodTrackerApp"])
-    ],
+    products: products,
     targets: [
         .executableTarget(
             name: "MoodTrackerApp",


### PR DESCRIPTION
## Summary
- switch package manifest to iOS application product targeting iOS 16
- provide required usage descriptions in a new Info.plist
- guard iOS app product behind macOS-only check and fix Info.plist path

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_b_68980e317848833082562875e84c993f