### PR TITLE
Refactor DiaryView to simplify SwiftUI view

### DIFF
--- a/MoodTrackerApp/MoodTrackerApp/Views/DiaryView.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Views/DiaryView.swift
@@ -14,69 +14,9 @@ struct DiaryView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 8) {
-                            ForEach(Array(chatHistory.enumerated()), id: \.element.id) { index, message in
-                                HStack {
-                                    if message.role == .user {
-                                        Spacer()
-                                        VStack(alignment: .trailing, spacing: 4) {
-                                            Text(message.text)
-                                                .padding(8)
-                                                .background(Color.blue.opacity(0.1))
-                                                .cornerRadius(8)
-                                            if let sentiment = message.sentiment {
-                                                Text("情绪: \(SentimentService.shared.label(for: sentiment)) (\(String(format: "%.2f", sentiment)))")
-                                                    .font(.caption)
-                                                    .foregroundColor(.secondary)
-                                            }
-                                        }
-                                    } else {
-                                        VStack(alignment: .leading, spacing: 4) {
-                                            Text(message.text)
-                                                .padding(8)
-                                                .background(Color.gray.opacity(0.1))
-                                                .cornerRadius(8)
-                                        }
-                                        Spacer()
-                                    }
-                                }
-                                .id(index)
-                            }
-                        }
-                        .padding()
-                    }
-                    .onChange(of: chatHistory) { _ in
-                        if let last = chatHistory.indices.last {
-                            proxy.scrollTo(last, anchor: .bottom)
-                        }
-                    }
-                }
-
+                chatList
                 Divider()
-                HStack {
-                    TextField("写下你的想法...", text: $diaryText, axis: .vertical)
-                        .textFieldStyle(.roundedBorder)
-                        .lineLimit(3)
-                    Button(action: sendMessage) {
-                        Image(systemName: "paperplane.fill")
-                            .font(.system(size: 20))
-                    }
-                    .disabled(diaryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    .padding(.leading, 8)
-                    Button(action: toggleRecording) {
-                        Image(systemName: speechService.isRecording ? "stop.circle" : "mic.fill")
-                            .font(.system(size: 20))
-                    }
-                    .padding(.leading, 4)
-                    Button(action: { showRatingSheet = true }) {
-                        Image(systemName: "face.smiling")
-                            .font(.system(size: 20))
-                    }
-                    .padding(.leading, 4)
-                }
-                .padding()
+                inputSection
             }
             .navigationTitle("心理日记")
             .toolbar {
@@ -89,17 +29,98 @@ struct DiaryView: View {
                 diaryText = text
             }
             .sheet(isPresented: $showRatingSheet) {
-                VStack(spacing: 20) {
-                    Text("情绪评分")
-                        .font(.title3)
-                    Slider(value: $rating, in: 1...10, step: 1)
-                    Text("评分: \(Int(rating))")
-                    Button("提交", action: sendRating)
-                        .padding(.top, 10)
+                ratingSheetContent
+            }
+        }
+    }
+
+    /// 聊天记录列表
+    private var chatList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(Array(chatHistory.enumerated()), id: \.element.id) { index, message in
+                        chatRow(message)
+                            .id(index)
+                    }
                 }
                 .padding()
             }
+            .onChange(of: chatHistory) { _ in
+                if let last = chatHistory.indices.last {
+                    proxy.scrollTo(last, anchor: .bottom)
+                }
+            }
         }
+    }
+
+    /// 单条聊天消息行
+    private func chatRow(_ message: ChatMessage) -> some View {
+        HStack {
+            if message.role == .user {
+                Spacer()
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(message.text)
+                        .padding(8)
+                        .background(Color.blue.opacity(0.1))
+                        .cornerRadius(8)
+                    if let sentiment = message.sentiment {
+                        let label = SentimentService.shared.label(for: sentiment)
+                        let formatted = String(format: "%.2f", sentiment)
+                        Text("情绪: \(label) (\(formatted))")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(message.text)
+                        .padding(8)
+                        .background(Color.gray.opacity(0.1))
+                        .cornerRadius(8)
+                }
+                Spacer()
+            }
+        }
+    }
+
+    /// 输入区域
+    private var inputSection: some View {
+        HStack {
+            TextField("写下你的想法...", text: $diaryText, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(3)
+            Button(action: sendMessage) {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: 20))
+            }
+            .disabled(diaryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .padding(.leading, 8)
+            Button(action: toggleRecording) {
+                Image(systemName: speechService.isRecording ? "stop.circle" : "mic.fill")
+                    .font(.system(size: 20))
+            }
+            .padding(.leading, 4)
+            Button(action: { showRatingSheet = true }) {
+                Image(systemName: "face.smiling")
+                    .font(.system(size: 20))
+            }
+            .padding(.leading, 4)
+        }
+        .padding()
+    }
+
+    /// 评分表单内容
+    private var ratingSheetContent: some View {
+        VStack(spacing: 20) {
+            Text("情绪评分")
+                .font(.title3)
+            Slider(value: $rating, in: 1...10, step: 1)
+            Text("评分: \(Int(rating))")
+            Button("提交", action: sendRating)
+                .padding(.top, 10)
+        }
+        .padding()
     }
 
     /// 发送用户输入的文本，并进行情感分析和持久化。


### PR DESCRIPTION
## Summary
- Refactor `DiaryView` layout into modular subviews to reduce type-checking complexity
- Simplify sentiment display with intermediate values

## Testing
- `swiftc MoodTrackerApp/MoodTrackerApp/Views/DiaryView.swift -o /tmp/diary.out`


------
https://chatgpt.com/codex/tasks/task_b_689877a9fd308330b6365c57f4b58d81