### PR TITLE
Improve AIService error handling

### DIFF
--- a/MoodTrackerApp/MoodTrackerApp/Views/DiaryView.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Views/DiaryView.swift
@@ -142,9 +142,16 @@ struct DiaryView: View {
         chatHistory = currentSession.messages
         diaryText = ""
         ChatStore.shared.saveSession(currentSession)
-        AIService.shared.chat(with: trimmed) { reply in
+        AIService.shared.chat(with: trimmed) { result in
             DispatchQueue.main.async {
-                let replyMessage = ChatMessage(role: .ai, text: reply)
+                let text: String
+                switch result {
+                case .success(let reply):
+                    text = reply
+                case .failure(let error):
+                    text = error.localizedDescription
+                }
+                let replyMessage = ChatMessage(role: .ai, text: text)
                 self.currentSession.messages.append(replyMessage)
                 self.chatHistory = self.currentSession.messages
                 ChatStore.shared.saveSession(self.currentSession)


### PR DESCRIPTION
## Summary
- Propagate descriptive errors from AIService by checking HTTP status and decoding OpenAI error payloads
- Update chat interface to use Result type and display errors in DiaryView

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68999efa614c83308e793c5d39280b15