### PR TITLE
Run file operations asynchronously and handle errors

### DIFF
--- a/MoodTrackerApp/MoodTrackerApp/Services/ChatStore.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Services/ChatStore.swift
@@ -10,23 +10,32 @@ final class ChatStore {
         fileURL = directory.appendingPathComponent("chat_sessions.json")
     }
     
-    func loadSessions() -> [ChatSession] {
-        guard let data = try? Data(contentsOf: fileURL),
-              let sessions = try? JSONDecoder().decode([ChatSession].self, from: data) else {
-            return []
-        }
-        return sessions.sorted { $0.date < $1.date }
+    func loadSessions() async throws -> [ChatSession] {
+        let url = fileURL
+        return try await Task.detached(priority: .background) {
+            guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+            let data = try Data(contentsOf: url)
+            let sessions = try JSONDecoder().decode([ChatSession].self, from: data)
+            return sessions.sorted { $0.date < $1.date }
+        }.value
     }
-    
-    func saveSession(_ session: ChatSession) {
-        var sessions = loadSessions()
-        if let index = sessions.firstIndex(where: { $0.id == session.id }) {
-            sessions[index] = session
-        } else {
-            sessions.append(session)
-        }
-        if let data = try? JSONEncoder().encode(sessions.sorted { $0.date < $1.date }) {
-            try? data.write(to: fileURL)
-        }
+
+    func saveSession(_ session: ChatSession) async throws {
+        let url = fileURL
+        let sessionToSave = session
+        try await Task.detached(priority: .background) {
+            var sessions: [ChatSession] = []
+            if FileManager.default.fileExists(atPath: url.path) {
+                let data = try Data(contentsOf: url)
+                sessions = try JSONDecoder().decode([ChatSession].self, from: data)
+            }
+            if let index = sessions.firstIndex(where: { $0.id == sessionToSave.id }) {
+                sessions[index] = sessionToSave
+            } else {
+                sessions.append(sessionToSave)
+            }
+            let data = try JSONEncoder().encode(sessions.sorted { $0.date < $1.date })
+            try data.write(to: url)
+        }.value
     }
 }

--- a/MoodTrackerApp/MoodTrackerApp/Views/DiaryHistoryView.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Views/DiaryHistoryView.swift
@@ -19,7 +19,13 @@ struct DiaryHistoryView: View {
         }
         .navigationTitle("日记记录")
         .onAppear {
-            sessions = ChatStore.shared.loadSessions().sorted { $0.date < $1.date }
+            Task {
+                do {
+                    sessions = try await ChatStore.shared.loadSessions()
+                } catch {
+                    print("Failed to load sessions: \(error)")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Run ChatStore load/save on background Task and propagate file IO errors
- Load and persist diary sessions asynchronously with error handling on the main actor

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -list` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_b_68999ef52340833082d93619e5be1588