### PR TITLE
Persist mood logs for AI features

### DIFF
--- a/MoodTrackerApp/MoodTrackerApp/Services/MoodLogStore.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Services/MoodLogStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+@MainActor
+final class MoodLogStore {
+    static let shared = MoodLogStore()
+    private let fileURL: URL
+
+    private init() {
+        let directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        fileURL = directory.appendingPathComponent("mood_logs.json")
+    }
+
+    func loadLogs() -> [MoodLog] {
+        guard let data = try? Data(contentsOf: fileURL),
+              let logs = try? JSONDecoder().decode([MoodLog].self, from: data) else {
+            return []
+        }
+        return logs.sorted { $0.time < $1.time }
+    }
+
+    func addLog(_ log: MoodLog) {
+        var logs = loadLogs()
+        logs.append(log)
+        if let data = try? JSONEncoder().encode(logs.sorted { $0.time < $1.time }) {
+            try? data.write(to: fileURL)
+        }
+    }
+
+    func recentLogs(days: Int) -> [MoodLog] {
+        let logs = loadLogs()
+        let startDate = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? Date()
+        return logs.filter { $0.time >= startDate }
+    }
+}
+

--- a/MoodTrackerApp/MoodTrackerApp/Views/DiaryView.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Views/DiaryView.swift
@@ -161,11 +161,24 @@ struct DiaryView: View {
 
     /// 发送情绪评分。
     private func sendRating() {
-        let text = "情绪评分: \(Int(rating))"
+        let score = Int(rating)
+        let text = "情绪评分: \(score)"
         let message = ChatMessage(role: .user, text: text, sentiment: nil)
         currentSession.messages.append(message)
         chatHistory = currentSession.messages
         ChatStore.shared.saveSession(currentSession)
+
+        let mood: String
+        switch score {
+        case ..<3: mood = "非常不好"
+        case 3..<5: mood = "不好"
+        case 5..<7: mood = "一般"
+        case 7..<9: mood = "好"
+        default: mood = "很好"
+        }
+        let log = MoodLog(time: Date(), mood: mood, description: text)
+        MoodLogStore.shared.addLog(log)
+
         showRatingSheet = false
         rating = 5
     }

--- a/MoodTrackerApp/MoodTrackerApp/Views/MoodTrendView.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Views/MoodTrendView.swift
@@ -4,8 +4,8 @@ import Charts
 
 /// 心情趋势视图，用于展示用户的情绪变化和节律评分趋势图。
 struct MoodTrendView: View {
-    /// 传入心情记录列表，可在实际使用时注入。
-    var moodLogs: [MoodLog] = []
+    /// 心情记录列表。
+    @State private var moodLogs: [MoodLog] = []
 
     /// 显示的时间范围，默认一周。
     @State private var selectedRange: TimeRange = .week
@@ -69,6 +69,9 @@ struct MoodTrendView: View {
         }
         .padding()
         .navigationTitle("心情趋势")
+        .onAppear {
+            moodLogs = MoodLogStore.shared.loadLogs()
+        }
     }
 }
 

--- a/MoodTrackerApp/MoodTrackerApp/Views/TimelineView.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Views/TimelineView.swift
@@ -117,7 +117,7 @@ struct TimelineView: View {
 
     /// 刷新建议日程，调用 AIService 获取个性化建议。
     private func generateSuggestions() {
-        let logs: [MoodLog] = [] // TODO: 收集真实心情日志
+        let logs = MoodLogStore.shared.recentLogs(days: 7)
         AIService.shared.getDailyScheduleSuggestions(from: logs) { result in
             DispatchQueue.main.async {
                 switch result {


### PR DESCRIPTION
## Summary
- add MoodLogStore for JSON-based mood history persistence
- store user mood ratings as MoodLog entries
- feed recent mood logs into AI suggestions and trend view

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6899b79ccc3483308cdc506504116043