### PR TITLE
Add local reminder scheduling for events and diary

### DIFF
--- a/MoodTrackerApp/MoodTrackerApp/ContentView.swift
+++ b/MoodTrackerApp/MoodTrackerApp/ContentView.swift
@@ -7,9 +7,24 @@
 
 import SwiftUI
 
+#if os(iOS)
+import UserNotifications
+#endif
+
 /// 主视图，包含底部标签栏用于在不同模块间切换。
 /// 该视图整合了时间轴、心理日记和个人中心等功能模块。
 struct ContentView: View {
+    @AppStorage("diaryNotificationsEnabled") private var diaryNotificationsEnabled: Bool = true
+    @AppStorage("diaryReminderHour") private var diaryReminderHour: Int = 21
+    @AppStorage("diaryReminderMinute") private var diaryReminderMinute: Int = 0
+
+    private var diaryReminderDate: Date {
+        var comps = DateComponents()
+        comps.hour = diaryReminderHour
+        comps.minute = diaryReminderMinute
+        return Calendar.current.date(from: comps) ?? Date()
+    }
+
     var body: some View {
         TabView {
             TimelineView()
@@ -29,6 +44,15 @@ struct ContentView: View {
                     Image(systemName: "person")
                     Text("我的")
                 }
+        }
+        .onAppear {
+            if diaryNotificationsEnabled {
+                NotificationService.shared.requestAuthorization { granted in
+                    if granted {
+                        NotificationService.shared.scheduleDiaryReminder(at: diaryReminderDate)
+                    }
+                }
+            }
         }
     }
 }

--- a/MoodTrackerApp/MoodTrackerApp/Services/NotificationService.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Services/NotificationService.swift
@@ -1,0 +1,69 @@
+import Foundation
+import UserNotifications
+
+/// 统一管理本地通知的服务。
+final class NotificationService {
+    static let shared = NotificationService()
+    private init() {}
+
+    private let center = UNUserNotificationCenter.current()
+    private let diaryIdentifier = "dailyDiaryReminder"
+
+    /// 请求通知权限，如已拒绝则回调 false。
+    func requestAuthorization(completion: ((Bool) -> Void)? = nil) {
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                self.center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+                    completion?(granted)
+                }
+            case .denied:
+                completion?(false)
+            default:
+                completion?(true)
+            }
+        }
+    }
+
+    /// 为建议事件安排通知，默认提前5分钟提醒。
+    func scheduleEventNotifications(for events: [SuggestedEvent], minutesBefore: Int = 5) {
+        let now = Date()
+        for event in events {
+            var triggerDate = event.time.addingTimeInterval(TimeInterval(-minutesBefore * 60))
+            if triggerDate < now { triggerDate = event.time }
+            guard triggerDate > now else { continue }
+
+            let content = UNMutableNotificationContent()
+            content.title = event.title
+            if let notes = event.notes { content.body = notes }
+            content.userInfo = ["id": event.id.uuidString]
+
+            let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: triggerDate)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+            let request = UNNotificationRequest(identifier: event.id.uuidString, content: content, trigger: trigger)
+            center.add(request)
+        }
+    }
+
+    /// 移除指定标识符的通知。
+    func cancelNotifications(ids: [String]) {
+        center.removePendingNotificationRequests(withIdentifiers: ids)
+    }
+
+    /// 安排每日的日记提醒。
+    func scheduleDiaryReminder(at date: Date) {
+        cancelDiaryReminder()
+        var components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        components.second = 0
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+        let content = UNMutableNotificationContent()
+        content.title = "记录一下今天的心情和想法吧"
+        let request = UNNotificationRequest(identifier: diaryIdentifier, content: content, trigger: trigger)
+        center.add(request)
+    }
+
+    /// 取消每日的日记提醒。
+    func cancelDiaryReminder() {
+        center.removePendingNotificationRequests(withIdentifiers: [diaryIdentifier])
+    }
+}


### PR DESCRIPTION
## Summary
- centralize permission and local notification scheduling in new NotificationService
- allow enabling schedule and diary reminders with time picker and permission guidance
- schedule diary reminder on launch and use service to manage event notifications

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_b_6899d63a2cc08330a83dffc465e4c7c8