### PR TITLE
Wrap iOS-only settings view imports

### DIFF
--- a/MoodTrackerApp/MoodTrackerApp/Views/SettingsView.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Views/SettingsView.swift
@@ -1,8 +1,8 @@
+// Only compile this view on iOS since it relies on UIKit and UserNotifications.
+#if os(iOS)
 import SwiftUI
 import UserNotifications
 import UIKit
-
-#if os(iOS)
 /// 设置页，允许用户配置 API Key、通知和数据选项等偏好。
 struct SettingsView: View {
     @State private var apiKeyInput: String = ""


### PR DESCRIPTION
## Summary
- ensure SettingsView imports are only compiled on iOS to prevent cross-platform build errors

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6899dd802cac8330b03e4900963142cb