### PR TITLE
Refresh timeline and sentiment analysis

### DIFF
--- a/MoodTrackerApp/MoodTrackerApp/Services/AIService.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Services/AIService.swift
@@ -11,6 +11,11 @@ final class AIService {
     static let shared = AIService()
     private init() {}
 
+    /// 默认系统提示，用于指导对话风格和范围
+    private let defaultSystemPrompt = """
+    你是一位温暖而专业的心理健康助理。你会通过提出开放式问题和共情的回应，引导用户表达自己的感受、事件和想法。不要提供医疗诊断或处方，避免使用负面或命令性的语句。当用户描述心情时，请鼓励他们详细记录情绪背后的原因。
+    """
+
     private let endpoint = URL(string: "https://api.openai.com/v1/chat/completions")!
     private let model = "gpt-3.5-turbo"
 
@@ -124,6 +129,8 @@ final class AIService {
         // 控制历史长度，避免超过 token 限制
         let recent = Array(messages.suffix(10))
         var messagePayload: [[String: String]] = []
+        // 无论是否存在摘要，始终添加默认系统提示，确保模型以友好、反思的语气回复
+        messagePayload.append(["role": "system", "content": PrivacyFilter.sanitize(defaultSystemPrompt)])
         if let summary = userSummary, !summary.isEmpty {
             messagePayload.append(["role": "system", "content": PrivacyFilter.sanitize(summary)])
         }

--- a/MoodTrackerApp/MoodTrackerApp/Services/SentimentService.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Services/SentimentService.swift
@@ -5,8 +5,30 @@ import NaturalLanguage
 final class SentimentService {
     static let shared = SentimentService()
     private init() {}
+
+    /// 自定义中文情感词表，用于弥补 NaturalLanguage 对中文支持有限的问题。
+    private let positiveKeywords: [String] = ["开心", "高兴", "快乐", "满意", "幸福", "喜悦", "兴奋", "期待"]
+    private let negativeKeywords: [String] = ["不开心", "难过", "悲伤", "沮丧", "生气", "愤怒", "压力", "抑郁", "焦虑"]
     
     func analyze(_ text: String) -> Double? {
+        // 先根据自定义词表判断中文情感倾向
+        var score: Double = 0
+        for word in positiveKeywords {
+            if text.contains(word) {
+                score += 1
+            }
+        }
+        for word in negativeKeywords {
+            if text.contains(word) {
+                score -= 1
+            }
+        }
+        if score > 0 {
+            return 0.5
+        } else if score < 0 {
+            return -0.5
+        }
+        // 若词表未覆盖，则调用系统情感分析作为退化方案
         if #available(iOS 13.0, macOS 10.15, *) {
             let tagger = NLTagger(tagSchemes: [.sentimentScore])
             tagger.string = text
@@ -19,12 +41,14 @@ final class SentimentService {
             return nil
         }
     }
-    
+
     func label(for score: Double) -> String {
-        switch score {
-        case let x where x > 0.2: return "积极"
-        case let x where x < -0.2: return "消极"
-        default: return "中性"
+        if score > 0.1 {
+            return "积极"
+        } else if score < -0.1 {
+            return "消极"
+        } else {
+            return "中性"
         }
     }
 }

--- a/MoodTrackerApp/MoodTrackerApp/Views/TimelineView.swift
+++ b/MoodTrackerApp/MoodTrackerApp/Views/TimelineView.swift
@@ -137,6 +137,11 @@ struct TimelineView: View {
                 }
                 try? viewContext.save()
             }
+
+            // 当视图首次出现且建议为空时，自动刷新一次以避免左侧时间轴为空。
+            if suggestedEvents.isEmpty {
+                generateSuggestions()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Auto-refresh suggestions on timeline appearance when no suggestions exist
- Add Chinese sentiment keyword lists with fallback NLP analysis and adjust thresholds
- Provide default system prompt for AI chat and prepend it to conversation payload

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_b_689b8407a73c83308c0be8cc1d0e234a